### PR TITLE
Fix weather API timezone handling

### DIFF
--- a/meteo/tests.py
+++ b/meteo/tests.py
@@ -1,3 +1,24 @@
-from django.test import TestCase
+from datetime import datetime as dt
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import TestCase
+from django.urls import reverse
+
+
+class TempHereViewTests(TestCase):
+    @patch('meteo.views.datetime')
+    @patch('meteo.views.requests.get')
+    @patch('meteo.views.geocoder.ip')
+    def test_timezone_auto_in_api_request(self, mock_geocoder_ip, mock_requests_get, mock_datetime):
+        mock_geocoder_ip.return_value.latlng = (0.0, 0.0)
+        mock_datetime.now.return_value = dt(2024, 1, 1, 5, 0, 0)
+        mock_requests_get.return_value.json.return_value = {
+            'hourly': {'temperature_2m': list(range(24))}
+        }
+
+        response = self.client.get(reverse('temp_here'))
+
+        self.assertEqual(response.status_code, 200)
+        args, kwargs = mock_requests_get.call_args
+        self.assertEqual(kwargs['params']['timezone'], 'auto')
+        self.assertIn('<h2>5&#8457;</h2>', response.content.decode())

--- a/meteo/views.py
+++ b/meteo/views.py
@@ -9,12 +9,17 @@ from django.template import loader
 def temp_here(request):
     endpoint = "https://api.open-meteo.com/v1/forecast"
     location = geocoder.ip('me').latlng
-    api_request = (f"{endpoint}?latitude={location[0]}&longitude={location[1]}&hourly=temperature_2m&temperature_unit"
-                   f"=fahrenheit")
+    params = {
+        "latitude": location[0],
+        "longitude": location[1],
+        "hourly": "temperature_2m",
+        "temperature_unit": "fahrenheit",
+        "timezone": "auto",
+    }
     now = datetime.now()
     hour = now.hour
-    meteo_data = requests.get(api_request).json()
+    meteo_data = requests.get(endpoint, params=params).json()
     temp = meteo_data['hourly']['temperature_2m'][hour]
     template = loader.get_template('index.html')
-    context = {'temp':temp}
+    context = {'temp': temp}
     return HttpResponse(template.render(context, request))


### PR DESCRIPTION
## Summary
- ensure Open-Meteo requests specify local timezone to match hourly temperatures
- add regression test for timezone parameter and correct temperature lookup

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dcf29f088327925d98a44d059dfa